### PR TITLE
Milestone 6: Friendships v2

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -3,14 +3,14 @@
 class FriendshipsController < ApplicationController
   def create
     user = User.find(params[:user_id])
-    return current_user.send_friend_request(user) if user
+    current_user.send_friend_request(user) if user
 
     redirect_back(fallback_location: root_path)
   end
 
   def update
     user = User.find(params[:id])
-    return current_user.confirm_friend(user) if user
+    current_user.confirm_friend(user) if user
 
     redirect_back(fallback_location: root_path)
   end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -19,4 +19,3 @@ class FriendshipsController < ApplicationController
     @friend_requests = current_user.friend_requests
   end
 end
-   

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -3,16 +3,17 @@
 class FriendshipsController < ApplicationController
   def create
     user = User.find(params[:user_id])
-    current_user.send_friend_request(user) if user
+    return unless user
 
+    current_user.send_friend_request(user)
     redirect_back(fallback_location: root_path)
   end
 
   def update
     user = User.find(params[:id])
-    current_user.confirm_friend(user) if user
-    Friendship.create sender_id: user.id, receiver_id: current_user.id, confirmed: true
+    return unless user
 
+    current_user.confirm_friend(user)
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -11,6 +11,7 @@ class FriendshipsController < ApplicationController
   def update
     user = User.find(params[:id])
     current_user.confirm_friend(user) if user
+    Friendship.create sender_id: user.id, receiver_id: current_user.id, confirmed: true
 
     redirect_back(fallback_location: root_path)
   end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -19,3 +19,4 @@ class FriendshipsController < ApplicationController
     @friend_requests = current_user.friend_requests
   end
 end
+   

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @posts = Post.all
+    @posts = current_user.news_feed
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,22 +36,24 @@ class User < ApplicationRecord
   end
 
   def friends
-    friends_array = received_requests.map do |u|
-      u.sender if u.confirmed
+    friendships = sent_requests.includes(:receiver).where(confirmed: true).references(:users)
+    friendships.map do |f|
+    f.receiver
     end
-
-    friends_array += sent_requests.map do |u|
-      u.receiver if u.confirmed
-    end
-    friends_array.compact
   end
 
   def pending_friends
-    sent_requests.map { |u| u.receiver unless u.confirmed }.compact
+    requests = sent_requests.includes(:receiver).where(confirmed: false).references(:users)
+    requests.map do |r|
+    r.receiver
+    end
   end
 
   def friend_requests
-    received_requests.map { |u| u.sender unless u.confirmed }.compact
+    requests = received_requests.includes(:sender).where(confirmed: false).references(:users)
+    requests.map do |r|
+    r.sender
+    end
   end
 
   def confirm_friend(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,39 +36,37 @@ class User < ApplicationRecord
   end
 
   def friends
-    friendships = sent_requests.includes(:receiver).where(confirmed: true).references(:users)
-    friendships.map do |f|
-    f.receiver
-    end
-  end
+  friendships = sent_requests.includes(:receiver).where(confirmed: true).references(:users)
+  friendships.map(&:receiver)
+end
 
-  def pending_friends
-    requests = sent_requests.includes(:receiver).where(confirmed: false).references(:users)
-    requests.map do |r|
-    r.receiver
-    end
-  end
+def pending_friends
+  requests = sent_requests.includes(:receiver).where(confirmed: false).references(:users)
+  requests.map(&:receiver)
+end
 
-  def friend_requests
-    requests = received_requests.includes(:sender).where(confirmed: false).references(:users)
-    requests.map do |r|
-    r.sender
-    end
-  end
+def friend_requests
+  requests = received_requests.includes(:sender).where(confirmed: false).references(:users)
+  requests.map(&:sender)
+end
 
-  def confirm_friend(user)
-    friendship = received_requests.find { |u| u.sender == user }
-    friendship.confirmed = true
-    friendship.save
-  end
+def confirm_friend(user)
+  friendship = received_requests.find { |u| u.sender == user }
+  friendship.confirmed = true
+  friendship.save
 
-  def send_friend_request(user)
-    sent_requests.create(receiver_id: user.id)
-  end
+  sent_requests.create(receiver_id: user.id, confirmed: true)
+end
 
-  def friend?(user)
-    friends.include?(user)
-  end
+def send_friend_request(user)
+  return if Friendship.exists?(sender_id: id, receiver_id: user.id) || user.id == id
+
+  sent_requests.create(receiver_id: user.id)
+end
+
+def friend?(user)
+  friends.include?(user)
+end
 
   def news_feed
     friend_ids = friends.map(&:id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,9 +68,8 @@ class User < ApplicationRecord
     friends.include?(user)
   end
 
-  def friends_posts
+  def news_feed
     friend_ids = friends.map(&:id)
-
-    Post.where('user_id IN (?)', friend_ids)
+    Post.where('user_id IN (?) OR user_id=?', friend_ids, id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,37 +36,37 @@ class User < ApplicationRecord
   end
 
   def friends
-  friendships = sent_requests.includes(:receiver).where(confirmed: true).references(:users)
-  friendships.map(&:receiver)
-end
+    friendships = sent_requests.includes(:receiver).where(confirmed: true).references(:users)
+    friendships.map(&:receiver)
+  end
 
-def pending_friends
-  requests = sent_requests.includes(:receiver).where(confirmed: false).references(:users)
-  requests.map(&:receiver)
-end
+  def pending_friends
+    requests = sent_requests.includes(:receiver).where(confirmed: false).references(:users)
+    requests.map(&:receiver)
+  end
 
-def friend_requests
-  requests = received_requests.includes(:sender).where(confirmed: false).references(:users)
-  requests.map(&:sender)
-end
+  def friend_requests
+    requests = received_requests.includes(:sender).where(confirmed: false).references(:users)
+    requests.map(&:sender)
+  end
 
-def confirm_friend(user)
-  friendship = received_requests.find { |u| u.sender == user }
-  friendship.confirmed = true
-  friendship.save
+  def confirm_friend(user)
+    friendship = received_requests.find { |u| u.sender == user }
+    friendship.confirmed = true
+    friendship.save
 
-  sent_requests.create(receiver_id: user.id, confirmed: true)
-end
+    sent_requests.create(receiver_id: user.id, confirmed: true)
+  end
 
-def send_friend_request(user)
-  return if Friendship.exists?(sender_id: id, receiver_id: user.id) || user.id == id
+  def send_friend_request(user)
+    return if Friendship.exists?(sender_id: id, receiver_id: user.id) || user.id == id
 
-  sent_requests.create(receiver_id: user.id)
-end
+    sent_requests.create(receiver_id: user.id)
+  end
 
-def friend?(user)
-  friends.include?(user)
-end
+  def friend?(user)
+    friends.include?(user)
+  end
 
   def news_feed
     friend_ids = friends.map(&:id)

--- a/db/migrate/20200110155538_change_sender_id_to_friendships.rb
+++ b/db/migrate/20200110155538_change_sender_id_to_friendships.rb
@@ -1,0 +1,5 @@
+class ChangeSenderIdToFriendships < ActiveRecord::Migration[6.0]
+  def change
+    change_column :friendships, :sender_id, :integer, null: false
+  end
+end

--- a/db/migrate/20200110155624_change_receiver_id_to_friendships.rb
+++ b/db/migrate/20200110155624_change_receiver_id_to_friendships.rb
@@ -1,0 +1,5 @@
+class ChangeReceiverIdToFriendships < ActiveRecord::Migration[6.0]
+  def change
+    change_column :friendships, :receiver_id, :integer, null: false
+  end
+end

--- a/db/migrate/20200110155646_add_indices_to_friendships.rb
+++ b/db/migrate/20200110155646_add_indices_to_friendships.rb
@@ -1,0 +1,7 @@
+class AddIndicesToFriendships < ActiveRecord::Migration[6.0]
+  def change
+    add_index :friendships, :sender_id
+    add_index :friendships, :receiver_id
+    add_index :friendships, [:sender_id, :receiver_id], unique: true
+  end
+end

--- a/db/migrate/20200110171152_change_confirmed_value_to_friendships.rb
+++ b/db/migrate/20200110171152_change_confirmed_value_to_friendships.rb
@@ -1,0 +1,5 @@
+class ChangeConfirmedValueToFriendships < ActiveRecord::Migration[6.0]
+  def change
+    change_column :friendships, :confirmed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_10_155646) do
+ActiveRecord::Schema.define(version: 2020_01_10_171152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2020_01_10_155646) do
   create_table "friendships", force: :cascade do |t|
     t.integer "sender_id", null: false
     t.integer "receiver_id", null: false
-    t.boolean "confirmed"
+    t.boolean "confirmed", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["receiver_id"], name: "index_friendships_on_receiver_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_160839) do
+ActiveRecord::Schema.define(version: 2020_01_10_155646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,11 +26,14 @@ ActiveRecord::Schema.define(version: 2020_01_08_160839) do
   end
 
   create_table "friendships", force: :cascade do |t|
-    t.integer "sender_id"
-    t.integer "receiver_id"
+    t.integer "sender_id", null: false
+    t.integer "receiver_id", null: false
     t.boolean "confirmed"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["receiver_id"], name: "index_friendships_on_receiver_id"
+    t.index ["sender_id", "receiver_id"], name: "index_friendships_on_sender_id_and_receiver_id", unique: true
+    t.index ["sender_id"], name: "index_friendships_on_sender_id"
   end
 
   create_table "likes", force: :cascade do |t|


### PR DESCRIPTION
### Building Facebook Milestone 6: Friendships v2

In this milestone we fixed the scenarios:

- When a user sends a request, the option to send another request should disappear.
- When a request is accepted, it should disappear from the notification bar.
- The friendship notifications are more visible.
- Rubocop fixed, no offenses detected.
